### PR TITLE
feat: Add (unused) parameter QSS3BucketRegion

### DIFF
--- a/templates/Trend-Micro-Cloud-One-Conformity-Lifecycle-QS.yaml
+++ b/templates/Trend-Micro-Cloud-One-Conformity-Lifecycle-QS.yaml
@@ -19,6 +19,7 @@ Metadata:
           default: "(Optional) AWS Quick Start configuration"
         Parameters:
           - QSS3BucketName
+          - QSS3BucketRegion
           - QSS3KeyPrefix
 
     ParameterLabels:
@@ -31,6 +32,8 @@ Metadata:
 
       QSS3BucketName:
         default: Quick Start S3 bucket name
+      QSS3BucketRegion:
+        default: Quick Start S3 bucket region
       QSS3KeyPrefix:
         default: Quick Start S3 key prefix
 
@@ -87,6 +90,12 @@ Parameters:
       "Quick Start bucket name can include numbers, lowercase letters, uppercase
       letters, and hyphens (-). It cannot start or end with a hyphen (-)."
     AllowedPattern: "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$"
+  QSS3BucketRegion:
+    Default: "us-east-1"
+    Description:
+      "The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is
+      hosted. When using your own bucket, you must specify this value."
+    Type: String
   QSS3KeyPrefix:
     Type: String
     Description:


### PR DESCRIPTION
*Description of changes:*

The Quick Start team requires that we add a `QSS3BucketRegion` parameter, which
is not actually needed for our template to work but is necessary for their
infrastructure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.