### PR TITLE
Delete costpackage parameter from conformity api request in account c…

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -1,0 +1,1 @@
+language_type: cloudformation

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -9,4 +9,4 @@ tests:
       CloudOneConformityRegion: 'us-west-2'
     regions:
       - us-west-2
-    template: trend-micro-cloud-one-conformity-lifecycle.template.yaml
+    template: templates/trend-micro-cloud-one-conformity-lifecycle.template.yaml

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -5,7 +5,7 @@ project:
 tests:
   onboarding-us-west-2:
     parameters:
-      ApiKey: ''
+      ApiKey: override
       CloudOneConformityRegion: 'us-west-2'
     regions:
       - us-west-2

--- a/functions/source/c1c_controltower_lifecycle.py
+++ b/functions/source/c1c_controltower_lifecycle.py
@@ -375,10 +375,6 @@ def lambda_handler(event, context):
                 update_policy(event["account_id"])
             elif event["InvokeAction"] == "remove_account_config":
                 remove_account_config(event["account_id"])
-            elif event["InvokeAction"] == "fresh_deploy": 
-                fresh_deploy(context.function_name)
-            elif event["InvokeAction"] == "remove_all":
-                remove_all(context.function_name)
             else:
                 logger.warn(
                     f'Unrecognized InvokeAction {event["InvokeAction"]} -- try one of configure_account, update_account, remove_account_config, remove_all'

--- a/functions/source/c1c_controltower_lifecycle.py
+++ b/functions/source/c1c_controltower_lifecycle.py
@@ -375,6 +375,8 @@ def lambda_handler(event, context):
                 update_policy(event["account_id"])
             elif event["InvokeAction"] == "remove_account_config":
                 remove_account_config(event["account_id"])
+            elif event["InvokeAction"] == "fresh_deploy": 
+                fresh_deploy(context.function_name)
             elif event["InvokeAction"] == "remove_all":
                 remove_all(context.function_name)
             else:

--- a/functions/source/c1cconnectorapi.py
+++ b/functions/source/c1cconnectorapi.py
@@ -54,7 +54,7 @@ class CloudOneConformityConnector:
                     "access": {
                         "keys": {"roleArn": role_arn, "externalId": self.external_id}
                     },
-                    "costPackage": False,
+                    #"costPackage": False,
                     "hasRealTimeMonitoring": True,
                 },
             }

--- a/functions/source/c1cconnectorapi.py
+++ b/functions/source/c1cconnectorapi.py
@@ -54,7 +54,6 @@ class CloudOneConformityConnector:
                     "access": {
                         "keys": {"roleArn": role_arn, "externalId": self.external_id}
                     },
-                    #"costPackage": False,
                     "hasRealTimeMonitoring": True,
                 },
             }

--- a/functions/source/c1cconnectorapi.py
+++ b/functions/source/c1cconnectorapi.py
@@ -11,7 +11,7 @@ DELETE = "DELETE"
 
 class CloudOneConformityConnector:
     def __init__(self, api_key):
-        self.base_url = "https://{region}-api.cloudconformity.com/v1".format(
+        self.base_url = "https://conformity.{region}.cloudone.trendmicro.com/api".format(
             region=os.environ["ConformityRegionEndpoint"]
         )
         self.api_key = api_key
@@ -54,6 +54,7 @@ class CloudOneConformityConnector:
                     "access": {
                         "keys": {"roleArn": role_arn, "externalId": self.external_id}
                     },
+                    #"costPackage": False,
                     "hasRealTimeMonitoring": True,
                 },
             }

--- a/templates/trend-micro-cloud-one-conformity-lifecycle.template.yaml
+++ b/templates/trend-micro-cloud-one-conformity-lifecycle.template.yaml
@@ -45,11 +45,19 @@ Parameters:
 
   CloudOneConformityRegion:
     Type: String
-    Default: us-west-2
+    Default: us-1
     AllowedValues:
-      - ap-southeast-2
-      - eu-west-1
-      - us-west-2
+      - us-1
+      - in-1
+      - gb-1
+      - de-1
+      - au-1
+      - jp-1
+      - ca-1
+      - sg-1
+      - ap-southeast-2  #This values are of Legacy API
+      - eu-west-1 #This values are of Legacy API
+      - us-west-2 #This values are of Legacy API
     Description: Cloud One Conformity Region endpoint for your account.
     AllowedPattern: ".+"
 


### PR DESCRIPTION
…reation, and adding the fresh_deploy inside the handler

*Issue 
"costPackage" parameter in account creation for conformity api it's deprecated.
#, if available:*

*Description of changes:*
Comment the line 57 #"costPackage": False, in c1cconnectorapi.py script 
adding fresh_deploy method to invoke actions for to make a test and re-deploy the creation of IAM Cross Account Roles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
